### PR TITLE
Fix dough slider range and reset: allow 0-100% instead of 5-95%

### DIFF
--- a/src/lib/components/recipe/IngredientCalculator.svelte
+++ b/src/lib/components/recipe/IngredientCalculator.svelte
@@ -345,8 +345,8 @@
 								class="slider"
 								bind:value={mainDoughFlourPercent}
 								oninput={handleMainDoughFlourChange}
-								min="5"
-								max="95"
+								min="0"
+								max="100"
 								step="1"
 							/>
 							<span class="flour-split-value">{mainDoughFlourPercent}%</span>

--- a/src/lib/stores/calculator.ts
+++ b/src/lib/stores/calculator.ts
@@ -119,8 +119,8 @@ function createCalculatorStore() {
 		 */
 		setPredoughRatio(ratio: number | null) {
 			if (ratio !== null) {
-				if (ratio < 0.05) ratio = 0.05; // Minimum 5%
-				if (ratio > 0.95) ratio = 0.95; // Maximum 95%
+				if (ratio < 0) ratio = 0;
+				if (ratio > 1) ratio = 1;
 			}
 
 			update((state) => {


### PR DESCRIPTION
The slider was clamped to min=5/max=95 in the HTML and 0.05-0.95 in the
store, preventing users from dragging to 0% or 100%. This also broke the
reset button for recipes like bk-biga-v1 where the original ratio is
100% predough (0% main), since the slider couldn't represent that value.

https://claude.ai/code/session_01PiX9ZGaUoigk5R7AxfhzGb